### PR TITLE
Relocate venv

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -143,6 +143,8 @@ if [ "$NAME" = "Python/Django" ]; then
   source $BIN_DIR/steps/django
 fi
 
+# Relocate venv
+source $BIN_DIR/steps/relocate
 
 # ### Finalize
 #

--- a/bin/steps/activate_this.py
+++ b/bin/steps/activate_this.py
@@ -1,0 +1,34 @@
+"""By using execfile(this_file, dict(__file__=this_file)) you will
+activate this virtualenv environment.
+
+This can be used when you must use an existing Python interpreter, not
+the virtualenv bin/python
+"""
+
+try:
+    __file__
+except NameError:
+    raise AssertionError(
+        "You must run this like execfile('path/to/activate_this.py', dict(__file__='path/to/activate_this.py'))")
+import sys
+import os
+
+old_os_path = os.environ['PATH']
+os.environ['PATH'] = os.path.dirname(os.path.abspath(__file__)) + os.pathsep + old_os_path
+base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if sys.platform == 'win32':
+    site_packages = os.path.join(base, 'Lib', 'site-packages')
+else:
+    site_packages = os.path.join(base, 'lib', 'python%s' % sys.version[:3], 'site-packages')
+prev_sys_path = list(sys.path)
+import site
+site.addsitedir(site_packages)
+sys.real_prefix = sys.prefix
+sys.prefix = base
+# Move the added items to the front of the path:
+new_sys_path = []
+for item in list(sys.path):
+    if item not in prev_sys_path:
+        new_sys_path.append(item)
+        sys.path.remove(item)
+sys.path[:0] = new_sys_path

--- a/bin/steps/relocate
+++ b/bin/steps/relocate
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+puts-step "Making venv relocatable"
+
+VIRTUALENV_BINDIR=$VIRTUALENV_LOC/bin
+HEADER='#!/usr/bin/env python3.4\n\nimport os\nactivate_this=os.path.join(os.path.dirname(os.path.realpath(__file__)), "activate_this.py")\nexec(compile(open(activate_this).read(), activate_this, "exec"))\ndel os, activate_this\n'
+
+puts-step "Copying activate script"
+cp $BIN_DIR/steps/activate_this.py $VIRTUALENV_BINDIR
+puts-step "Rewriting headers"
+for exe in $VIRTUALENV_BINDIR/*; do
+    puts-step "Doing" $exe
+    sed -i "0,/^#!.*python.*$/s||$HEADER|" $exe
+done;
+puts-step "Done"


### PR DESCRIPTION
Modify scripts in venv/bin so that they don't hardcode python interpreter's path.
