### PR TITLE
Allow env vars to be set before the build process starts if desired

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,6 +73,14 @@ source $BIN_DIR/utils
 # Switch to the repo's context.
 cd $BUILD_DIR
 
+# Export custom env vars if defined
+if [ -f bin/compile_env ]; then
+    puts-step "Exporting variables from bin/compile_env"
+    set -o allexport
+    source bin/compile_env
+    set +o allexport
+fi
+
 # Run pre_compile hook.
 run-hook bin/pre_compile
 


### PR DESCRIPTION
This adds support for a new bin/compile_env hook, which if found will
be sourced with the "allexport" option activated in order to support
simple ".env"-style variable declarations.